### PR TITLE
updating versepuller for kri ukhtiv

### DIFF
--- a/.ipynb_checkpoints/verse_puller-checkpoint.ipynb
+++ b/.ipynb_checkpoints/verse_puller-checkpoint.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -549,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -687,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,7 +731,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def qkparse(string):\n",
+    "    start = string.index('<span class=\\\"mam-kq\">')\n",
+    "    string_before = string[0:start]\n",
+    "    startk = string.index('<span class=\\\"mam-kq-k\\\">',start)\n",
+    "    startk = string.index('>',startk)+2\n",
+    "    endk = string.index('</span>',startk)-1\n",
+    "    ktext = string[startk:endk]\n",
+    "    startq = string.index('<span class=\\\"mam-kq-q\\\">')\n",
+    "    startq = string.index('>',startq)+2\n",
+    "    endq = string.index('</span>',startq)-1\n",
+    "    qtext=string[startq:endq]\n",
+    "    end = string.index('</span></span>',endq)\n",
+    "    end = string.index(' ',end)\n",
+    "    output = '\\\\qk{'+qtext+'}{'+ktext+'}'\n",
+    "    string_after = string[end:]\n",
+    "    return string_before+output+string_after"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -769,6 +793,9 @@
     "    \n",
     "    #these run text converters, if the relevant items are listed in the query under \"convert\"\n",
     "    if \"convert\" in parameters.keys():\n",
+    "        if 'qk' in parameters[\"convert\"]:\n",
+    "            while '<span class=\\\"mam-kq\\\">' in verses:\n",
+    "                verses = qkparse(verses)\n",
     "        if \"removeHTML\" in parameters[\"convert\"]:\n",
     "            verses = removeformatting(verses)\n",
     "        if \"shemyy\" in parameters[\"convert\"]:\n",
@@ -812,7 +839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -833,7 +860,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -848,6 +875,7 @@
     "\n",
     "#convert determines what text converters to run the text through.\n",
     "#you can have multiple &convert=... statements\n",
+    "#qk puts a kri ukhtiv into a LaTeX command \\qk{}{}\n",
     "#removeHTML removes the formatting statements in <>\n",
     "#shemyy converts the 4-letter shem to double-yod\n",
     "#shva adds marking for shva na using a rafe\n",
@@ -861,23 +889,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://www.sefaria.org/api/texts/Genesis.1:1?vhe=Miqra_according_to_the_Masorah&context=0\n"
+      "https://www.sefaria.org/api/texts/Daniel.9?vhe=Miqra_according_to_the_Masorah&context=0\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃'"
+       "'בִּשְׁנַ֣ת אַחַ֗ת לְדָרְיָ֛וֶשׁ בֶּן־אֲחַשְׁוֵר֖וֹשׁ מִזֶּ֣רַע מָדָ֑י אֲשֶׁ֣ר הׇמְלַ֔ךְ עַ֖ל מַלְכ֥וּת כַּשְׂדִּֽים׃ בִּשְׁנַ֤ת אַחַת֙ לְמׇלְכ֔וֹ אֲנִי֙ דָּֽנִיֵּ֔אל בִּינֹ֖תִי בַּסְּפָרִ֑ים מִסְפַּ֣ר הַשָּׁנִ֗ים אֲשֶׁ֨ר הָיָ֤ה דְבַר־יְיָ֙ אֶל־יִרְמְיָ֣ה הַנָּבִ֔יא לְמַלֹּ֛אות לְחׇרְב֥וֹת יְרוּשָׁלַ֖͏ִם שִׁבְעִ֥ים שָׁנָֽה׃ וָאֶתְּנָ֣ה אֶת־פָּנַ֗י אֶל־אֲדֹנָי֙ הָֽאֱלֹהִ֔ים לְבַקֵּ֥שׁ תְּפִלָּ֖ה וְתַחֲנוּנִ֑ים בְּצ֖וֹם וְשַׂ֥ק וָאֵֽפֶר׃ וָֽאֶתְפַּֽלְלָ֛ה לַייָ֥ אֱלֹהַ֖י וָאֶתְוַדֶּ֑ה וָאֹֽמְרָ֗ה אָנָּ֤א אֲדֹנָי֙ הָאֵ֤ל הַגָּדוֹל֙ וְהַנּוֹרָ֔א שֹׁמֵ֤ר הַבְּרִית֙ וְֽהַחֶ֔סֶד לְאֹהֲבָ֖יו וּלְשֹׁמְרֵ֥י מִצְוֺתָֽיו׃ חָטָ֥אנוּ וְעָוִ֖ינוּ \\\\qk{הִרְשַׁ֣עְנוּ}{והרשענו} וּמָרָ֑דְנוּ וְס֥וֹר מִמִּצְוֺתֶ֖ךָ וּמִמִּשְׁפָּטֶֽיךָ׃ וְלֹ֤א שָׁמַ֙עְנוּ֙ אֶל־עֲבָדֶ֣יךָ הַנְּבִיאִ֔ים אֲשֶׁ֤ר דִּבְּרוּ֙ בְּשִׁמְךָ֔ אֶל־מְלָכֵ֥ינוּ שָׂרֵ֖ינוּ וַאֲבֹתֵ֑ינוּ וְאֶ֖ל כׇּל־עַ֥ם הָאָֽרֶץ׃ לְךָ֤ אֲדֹנָי֙ הַצְּדָקָ֔ה וְלָ֛נוּ בֹּ֥שֶׁת הַפָּנִ֖ים כַּיּ֣וֹם הַזֶּ֑ה לְאִ֤ישׁ יְהוּדָה֙ וּלְיֹשְׁבֵ֣י יְרֽוּשָׁלַ֔͏ִם וּֽלְכׇל־יִשְׂרָאֵ֞ל הַקְּרֹבִ֣ים וְהָרְחֹקִ֗ים בְּכׇל־הָֽאֲרָצוֹת֙ אֲשֶׁ֣ר הִדַּחְתָּ֣ם שָׁ֔ם בְּמַעֲלָ֖ם אֲשֶׁ֥ר מָֽעֲלוּ־בָֽךְ׃ יְיָ֗ לָ֚נוּ בֹּ֣שֶׁת הַפָּנִ֔ים לִמְלָכֵ֥ינוּ לְשָׂרֵ֖ינוּ וְלַאֲבֹתֵ֑ינוּ אֲשֶׁ֥ר חָטָ֖אנוּ לָֽךְ׃ לַֽאדֹנָ֣י אֱלֹהֵ֔ינוּ הָרַחֲמִ֖ים וְהַסְּלִח֑וֹת כִּ֥י מָרַ֖דְנוּ בּֽוֹ׃ וְלֹ֣א שָׁמַ֔עְנוּ בְּק֖וֹל יְיָ֣ אֱלֹהֵ֑ינוּ לָלֶ֤כֶת בְּתֽוֹרֹתָיו֙ אֲשֶׁ֣ר נָתַ֣ן לְפָנֵ֔ינוּ בְּיַ֖ד עֲבָדָ֥יו הַנְּבִיאִֽים׃ וְכׇל־יִשְׂרָאֵ֗ל עָֽבְרוּ֙ אֶת־תּ֣וֹרָתֶ֔ךָ וְס֕וֹר לְבִלְתִּ֖י שְׁמ֣וֹעַ בְּקֹלֶ֑ךָ וַתִּתַּ֨ךְ עָלֵ֜ינוּ הָאָלָ֣ה וְהַשְּׁבֻעָ֗ה אֲשֶׁ֤ר כְּתוּבָה֙ בְּתוֹרַת֙ מֹשֶׁ֣ה עֶֽבֶד־הָֽאֱלֹהִ֔ים כִּ֥י חָטָ֖אנוּ לֽוֹ׃ וַיָּ֜קֶם אֶת־\\\\qk{דְּבָר֣וֹ ׀}{דבריו} אֲשֶׁר־דִּבֶּ֣ר עָלֵ֗ינוּ וְעַ֤ל שֹֽׁפְטֵ֙ינוּ֙ אֲשֶׁ֣ר שְׁפָט֔וּנוּ לְהָבִ֥יא עָלֵ֖ינוּ רָעָ֣ה גְדֹלָ֑ה אֲשֶׁ֣ר לֹֽא־נֶעֶשְׂתָ֗ה תַּ֚חַת כׇּל־הַשָּׁמַ֔יִם כַּאֲשֶׁ֥ר נֶעֶשְׂתָ֖ה בִּירוּשָׁלָֽ͏ִם׃ כַּאֲשֶׁ֤ר כָּתוּב֙ בְּתוֹרַ֣ת מֹשֶׁ֔ה אֵ֛ת כׇּל־הָרָעָ֥ה הַזֹּ֖את בָּ֣אָה עָלֵ֑ינוּ וְלֹֽא־חִלִּ֜ינוּ אֶת־פְּנֵ֣י ׀ יְיָ֣ אֱלֹהֵ֗ינוּ לָשׁוּב֙ מֵֽעֲוֺנֵ֔נוּ וּלְהַשְׂכִּ֖יל בַּאֲמִתֶּֽךָ׃ וַיִּשְׁקֹ֤ד יְיָ֙ עַל־הָ֣רָעָ֔ה וַיְבִיאֶ֖הָ עָלֵ֑ינוּ כִּֽי־צַדִּ֞יק יְיָ֣ אֱלֹהֵ֗ינוּ עַל־כׇּל־מַֽעֲשָׂיו֙ אֲשֶׁ֣ר עָשָׂ֔ה וְלֹ֥א שָׁמַ֖עְנוּ בְּקֹלֽוֹ׃ וְעַתָּ֣ה ׀ אֲדֹנָ֣י אֱלֹהֵ֗ינוּ אֲשֶׁר֩ הוֹצֵ֨אתָ אֶֽת־עַמְּךָ֜ מֵאֶ֤רֶץ מִצְרַ֙יִם֙ בְּיָ֣ד חֲזָקָ֔ה וַתַּֽעַשׂ־לְךָ֥ שֵׁ֖ם כַּיּ֣וֹם הַזֶּ֑ה חָטָ֖אנוּ רָשָֽׁעְנוּ׃ אֲדֹנָ֗י כְּכׇל־צִדְקֹתֶ֙ךָ֙ יָֽשׇׁב־נָ֤א אַפְּךָ֙ וַחֲמָ֣תְךָ֔ מֵעִֽירְךָ֥ יְרוּשָׁלַ֖͏ִם הַר־קׇדְשֶׁ֑ךָ כִּ֤י בַחֲטָאֵ֙ינוּ֙ וּבַעֲוֺנ֣וֹת אֲבֹתֵ֔ינוּ יְרוּשָׁלַ֧͏ִם וְעַמְּךָ֛ לְחֶרְפָּ֖ה לְכׇל־סְבִיבֹתֵֽינוּ׃ וְעַתָּ֣ה ׀ שְׁמַ֣ע אֱלֹהֵ֗ינוּ אֶל־תְּפִלַּ֤ת עַבְדְּךָ֙ וְאֶל־תַּ֣חֲנוּנָ֔יו וְהָאֵ֣ר פָּנֶ֔יךָ עַל־מִקְדָּשְׁךָ֖ הַשָּׁמֵ֑ם לְמַ֖עַן אֲדֹנָֽי׃ הַטֵּ֨ה אֱלֹהַ֥י ׀ אׇזְנְךָ֮ וּֽשְׁמָע֒ \\\\qk{פְּקַ֣ח}{פקחה} עֵינֶ֗יךָ וּרְאֵה֙ שֹֽׁמְמֹתֵ֔ינוּ וְהָעִ֕יר אֲשֶׁר־נִקְרָ֥א שִׁמְךָ֖ עָלֶ֑יהָ כִּ֣י ׀ לֹ֣א עַל־צִדְקֹתֵ֗ינוּ אֲנַ֨חְנוּ מַפִּילִ֤ים תַּחֲנוּנֵ֙ינוּ֙ לְפָנֶ֔יךָ כִּ֖י עַל־רַחֲמֶ֥יךָ הָרַבִּֽים׃ אֲדֹנָ֤י ׀ שְׁמָ֙עָה֙ אֲדֹנָ֣י ׀ סְלָ֔חָה אֲדֹנָ֛י הַֽקְשִׁ֥יבָה וַעֲשֵׂ֖ה אַל־תְּאַחַ֑ר לְמַֽעַנְךָ֣ אֱלֹהַ֔י כִּֽי־שִׁמְךָ֣ נִקְרָ֔א עַל־עִירְךָ֖ וְעַל־עַמֶּֽךָ׃ וְע֨וֹד אֲנִ֤י מְדַבֵּר֙ וּמִתְפַּלֵּ֔ל וּמִתְוַדֶּה֙ חַטָּאתִ֔י וְחַטַּ֖את עַמִּ֣י יִשְׂרָאֵ֑ל וּמַפִּ֣יל תְּחִנָּתִ֗י לִפְנֵי֙ יְיָ֣ אֱלֹהַ֔י עַ֖ל הַר־קֹ֥דֶשׁ אֱלֹהָֽי׃ וְע֛וֹד אֲנִ֥י מְדַבֵּ֖ר בַּתְּפִלָּ֑ה וְהָאִ֣ישׁ גַּבְרִיאֵ֡ל אֲשֶׁר֩ רָאִ֨יתִי בֶחָז֤וֹן בַּתְּחִלָּה֙ מֻעָ֣ף בִּיעָ֔ף נֹגֵ֣עַ אֵלַ֔י כְּעֵ֖ת מִנְחַת־עָֽרֶב׃ וַיָּ֖בֶן וַיְדַבֵּ֣ר עִמִּ֑י וַיֹּאמַ֕ר דָּנִיֵּ֕אל עַתָּ֥ה יָצָ֖אתִי לְהַשְׂכִּילְךָ֥ בִינָֽה׃ בִּתְחִלַּ֨ת תַּחֲנוּנֶ֜יךָ יָצָ֣א דָבָ֗ר וַאֲנִי֙ בָּ֣אתִי לְהַגִּ֔יד כִּ֥י חֲמוּד֖וֹת אָ֑תָּה וּבִין֙ בַּדָּבָ֔ר וְהָבֵ֖ן בַּמַּרְאֶֽה׃ שָׁבֻעִ֨ים שִׁבְעִ֜ים נֶחְתַּ֥ךְ עַֽל־עַמְּךָ֣ ׀ וְעַל־עִ֣יר קׇדְשֶׁ֗ךָ לְכַלֵּ֨א הַפֶּ֜שַׁע \\\\qk{וּלְהָתֵ֤ם}{ולחתם} \\\\qk{חַטָּאת֙}{חטאות} וּלְכַפֵּ֣ר עָוֺ֔ן וּלְהָבִ֖יא צֶ֣דֶק עֹֽלָמִ֑ים וְלַחְתֹּם֙ חָז֣וֹן וְנָבִ֔יא וְלִמְשֹׁ֖חַ קֹ֥דֶשׁ קׇֽדָשִֽׁים׃ וְתֵדַ֨ע וְתַשְׂכֵּ֜ל מִן־מֹצָ֣א דָבָ֗ר לְהָשִׁיב֙ וְלִבְנ֤וֹת יְרֽוּשָׁלַ֙͏ִם֙ עַד־מָשִׁ֣יחַ נָגִ֔יד שָׁבֻעִ֖ים שִׁבְעָ֑ה וְשָׁבֻעִ֞ים שִׁשִּׁ֣ים וּשְׁנַ֗יִם תָּשׁוּב֙ וְנִבְנְתָה֙ רְח֣וֹב וְחָר֔וּץ וּבְצ֖וֹק הָעִתִּֽים׃ וְאַחֲרֵ֤י הַשָּׁבֻעִים֙ שִׁשִּׁ֣ים וּשְׁנַ֔יִם יִכָּרֵ֥ת מָשִׁ֖יחַ וְאֵ֣ין ל֑וֹ וְהָעִ֨יר וְהַקֹּ֜דֶשׁ יַ֠שְׁחִ֠ית עַ֣ם נָגִ֤יד הַבָּא֙ וְקִצּ֣וֹ בַשֶּׁ֔טֶף וְעַד֙ קֵ֣ץ מִלְחָמָ֔ה נֶחֱרֶ֖צֶת שֹׁמֵמֽוֹת׃ וְהִגְבִּ֥יר בְּרִ֛ית לָרַבִּ֖ים שָׁב֣וּעַ אֶחָ֑ד וַחֲצִ֨י הַשָּׁב֜וּעַ יַשְׁבִּ֣ית ׀ זֶ֣בַח וּמִנְחָ֗ה וְעַ֨ל כְּנַ֤ף שִׁקּוּצִים֙ מְשֹׁמֵ֔ם וְעַד־כָּלָה֙ וְנֶ֣חֱרָצָ֔ה תִּתַּ֖ךְ עַל־שֹׁמֵֽם׃ '"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -885,14 +913,14 @@
    "source": [
     "#sample implementations:\n",
     "test = \"%?text=Berakhot.3a&convert=shva\"\n",
-    "test = \"%?text=Genesis.1:1&convert=shemyy&version=MAPM&convert=removeHTML \\n\"\n",
+    "test = \"%?text=Daniel.9&convert=shemyy&convert=qk&version=MAPM&convert=removeHTML \\n\"\n",
     "parserequest(test)\n",
     "#parserequest(test2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
@@ -1085,13 +1113,34 @@
      "text": [
       "https://www.sefaria.org/api/texts/Numbers.28:4-5?vhe=Miqra_according_to_the_Masorah&context=0\n",
       "https://www.sefaria.org/api/texts/Numbers.28:6-10?vhe=Miqra_according_to_the_Masorah&context=0\n",
-      "https://www.sefaria.org/api/texts/Numbers.28:11-15?vhe=Miqra_according_to_the_Masorah&context=0\n"
+      "https://www.sefaria.org/api/texts/Numbers.28:11-15?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Exodus.13:1-4?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Exodus.13:5-10?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Exodus.13:11-16?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Exodus.22:24-26?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Exodus.22:27-23:5?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Exodus.23:6-19?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Exodus.34:1-10?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Exodus.34:11-17?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Exodus.34:18-26?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Numbers.9:1-5?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Numbers.9:6-8?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Numbers.9:9-14?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Numbers.28:19-25?vhe=Miqra_according_to_the_Masorah&context=0\n",
+      "https://www.sefaria.org/api/texts/Numbers.29:17-34?vhe=Miqra_according_to_the_Masorah&context=0\n"
      ]
     }
    ],
    "source": [
-    "TeXconverter('weekday_torah_readings.tex','weekday_torah_readings_expanded.tex')"
+    "TeXconverter('weekday_torah_readings_raw.tex','weekday_torah_readings.tex')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/verse_puller.ipynb
+++ b/verse_puller.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -549,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -687,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,7 +731,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def qkparse(string):\n",
+    "    start = string.index('<span class=\\\"mam-kq\">')\n",
+    "    string_before = string[0:start]\n",
+    "    startk = string.index('<span class=\\\"mam-kq-k\\\">',start)\n",
+    "    startk = string.index('>',startk)+2\n",
+    "    endk = string.index('</span>',startk)-1\n",
+    "    ktext = string[startk:endk]\n",
+    "    startq = string.index('<span class=\\\"mam-kq-q\\\">')\n",
+    "    startq = string.index('>',startq)+2\n",
+    "    endq = string.index('</span>',startq)-1\n",
+    "    qtext=string[startq:endq]\n",
+    "    end = string.index('</span></span>',endq)\n",
+    "    end = string.index(' ',end)\n",
+    "    output = '\\\\qk{'+qtext+'}{'+ktext+'}'\n",
+    "    string_after = string[end:]\n",
+    "    return string_before+output+string_after"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -769,6 +793,9 @@
     "    \n",
     "    #these run text converters, if the relevant items are listed in the query under \"convert\"\n",
     "    if \"convert\" in parameters.keys():\n",
+    "        if 'qk' in parameters[\"convert\"]:\n",
+    "            while '<span class=\\\"mam-kq\\\">' in verses:\n",
+    "                verses = qkparse(verses)\n",
     "        if \"removeHTML\" in parameters[\"convert\"]:\n",
     "            verses = removeformatting(verses)\n",
     "        if \"shemyy\" in parameters[\"convert\"]:\n",
@@ -812,7 +839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -833,7 +860,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -848,6 +875,7 @@
     "\n",
     "#convert determines what text converters to run the text through.\n",
     "#you can have multiple &convert=... statements\n",
+    "#qk puts a kri ukhtiv into a LaTeX command \\qk{}{}\n",
     "#removeHTML removes the formatting statements in <>\n",
     "#shemyy converts the 4-letter shem to double-yod\n",
     "#shva adds marking for shva na using a rafe\n",
@@ -861,23 +889,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://www.sefaria.org/api/texts/Genesis.1:1?vhe=Miqra_according_to_the_Masorah&context=0\n"
+      "https://www.sefaria.org/api/texts/Daniel.9?vhe=Miqra_according_to_the_Masorah&context=0\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃'"
+       "'בִּשְׁנַ֣ת אַחַ֗ת לְדָרְיָ֛וֶשׁ בֶּן־אֲחַשְׁוֵר֖וֹשׁ מִזֶּ֣רַע מָדָ֑י אֲשֶׁ֣ר הׇמְלַ֔ךְ עַ֖ל מַלְכ֥וּת כַּשְׂדִּֽים׃ בִּשְׁנַ֤ת אַחַת֙ לְמׇלְכ֔וֹ אֲנִי֙ דָּֽנִיֵּ֔אל בִּינֹ֖תִי בַּסְּפָרִ֑ים מִסְפַּ֣ר הַשָּׁנִ֗ים אֲשֶׁ֨ר הָיָ֤ה דְבַר־יְיָ֙ אֶל־יִרְמְיָ֣ה הַנָּבִ֔יא לְמַלֹּ֛אות לְחׇרְב֥וֹת יְרוּשָׁלַ֖͏ִם שִׁבְעִ֥ים שָׁנָֽה׃ וָאֶתְּנָ֣ה אֶת־פָּנַ֗י אֶל־אֲדֹנָי֙ הָֽאֱלֹהִ֔ים לְבַקֵּ֥שׁ תְּפִלָּ֖ה וְתַחֲנוּנִ֑ים בְּצ֖וֹם וְשַׂ֥ק וָאֵֽפֶר׃ וָֽאֶתְפַּֽלְלָ֛ה לַייָ֥ אֱלֹהַ֖י וָאֶתְוַדֶּ֑ה וָאֹֽמְרָ֗ה אָנָּ֤א אֲדֹנָי֙ הָאֵ֤ל הַגָּדוֹל֙ וְהַנּוֹרָ֔א שֹׁמֵ֤ר הַבְּרִית֙ וְֽהַחֶ֔סֶד לְאֹהֲבָ֖יו וּלְשֹׁמְרֵ֥י מִצְוֺתָֽיו׃ חָטָ֥אנוּ וְעָוִ֖ינוּ \\\\qk{הִרְשַׁ֣עְנוּ}{והרשענו} וּמָרָ֑דְנוּ וְס֥וֹר מִמִּצְוֺתֶ֖ךָ וּמִמִּשְׁפָּטֶֽיךָ׃ וְלֹ֤א שָׁמַ֙עְנוּ֙ אֶל־עֲבָדֶ֣יךָ הַנְּבִיאִ֔ים אֲשֶׁ֤ר דִּבְּרוּ֙ בְּשִׁמְךָ֔ אֶל־מְלָכֵ֥ינוּ שָׂרֵ֖ינוּ וַאֲבֹתֵ֑ינוּ וְאֶ֖ל כׇּל־עַ֥ם הָאָֽרֶץ׃ לְךָ֤ אֲדֹנָי֙ הַצְּדָקָ֔ה וְלָ֛נוּ בֹּ֥שֶׁת הַפָּנִ֖ים כַּיּ֣וֹם הַזֶּ֑ה לְאִ֤ישׁ יְהוּדָה֙ וּלְיֹשְׁבֵ֣י יְרֽוּשָׁלַ֔͏ִם וּֽלְכׇל־יִשְׂרָאֵ֞ל הַקְּרֹבִ֣ים וְהָרְחֹקִ֗ים בְּכׇל־הָֽאֲרָצוֹת֙ אֲשֶׁ֣ר הִדַּחְתָּ֣ם שָׁ֔ם בְּמַעֲלָ֖ם אֲשֶׁ֥ר מָֽעֲלוּ־בָֽךְ׃ יְיָ֗ לָ֚נוּ בֹּ֣שֶׁת הַפָּנִ֔ים לִמְלָכֵ֥ינוּ לְשָׂרֵ֖ינוּ וְלַאֲבֹתֵ֑ינוּ אֲשֶׁ֥ר חָטָ֖אנוּ לָֽךְ׃ לַֽאדֹנָ֣י אֱלֹהֵ֔ינוּ הָרַחֲמִ֖ים וְהַסְּלִח֑וֹת כִּ֥י מָרַ֖דְנוּ בּֽוֹ׃ וְלֹ֣א שָׁמַ֔עְנוּ בְּק֖וֹל יְיָ֣ אֱלֹהֵ֑ינוּ לָלֶ֤כֶת בְּתֽוֹרֹתָיו֙ אֲשֶׁ֣ר נָתַ֣ן לְפָנֵ֔ינוּ בְּיַ֖ד עֲבָדָ֥יו הַנְּבִיאִֽים׃ וְכׇל־יִשְׂרָאֵ֗ל עָֽבְרוּ֙ אֶת־תּ֣וֹרָתֶ֔ךָ וְס֕וֹר לְבִלְתִּ֖י שְׁמ֣וֹעַ בְּקֹלֶ֑ךָ וַתִּתַּ֨ךְ עָלֵ֜ינוּ הָאָלָ֣ה וְהַשְּׁבֻעָ֗ה אֲשֶׁ֤ר כְּתוּבָה֙ בְּתוֹרַת֙ מֹשֶׁ֣ה עֶֽבֶד־הָֽאֱלֹהִ֔ים כִּ֥י חָטָ֖אנוּ לֽוֹ׃ וַיָּ֜קֶם אֶת־\\\\qk{דְּבָר֣וֹ ׀}{דבריו} אֲשֶׁר־דִּבֶּ֣ר עָלֵ֗ינוּ וְעַ֤ל שֹֽׁפְטֵ֙ינוּ֙ אֲשֶׁ֣ר שְׁפָט֔וּנוּ לְהָבִ֥יא עָלֵ֖ינוּ רָעָ֣ה גְדֹלָ֑ה אֲשֶׁ֣ר לֹֽא־נֶעֶשְׂתָ֗ה תַּ֚חַת כׇּל־הַשָּׁמַ֔יִם כַּאֲשֶׁ֥ר נֶעֶשְׂתָ֖ה בִּירוּשָׁלָֽ͏ִם׃ כַּאֲשֶׁ֤ר כָּתוּב֙ בְּתוֹרַ֣ת מֹשֶׁ֔ה אֵ֛ת כׇּל־הָרָעָ֥ה הַזֹּ֖את בָּ֣אָה עָלֵ֑ינוּ וְלֹֽא־חִלִּ֜ינוּ אֶת־פְּנֵ֣י ׀ יְיָ֣ אֱלֹהֵ֗ינוּ לָשׁוּב֙ מֵֽעֲוֺנֵ֔נוּ וּלְהַשְׂכִּ֖יל בַּאֲמִתֶּֽךָ׃ וַיִּשְׁקֹ֤ד יְיָ֙ עַל־הָ֣רָעָ֔ה וַיְבִיאֶ֖הָ עָלֵ֑ינוּ כִּֽי־צַדִּ֞יק יְיָ֣ אֱלֹהֵ֗ינוּ עַל־כׇּל־מַֽעֲשָׂיו֙ אֲשֶׁ֣ר עָשָׂ֔ה וְלֹ֥א שָׁמַ֖עְנוּ בְּקֹלֽוֹ׃ וְעַתָּ֣ה ׀ אֲדֹנָ֣י אֱלֹהֵ֗ינוּ אֲשֶׁר֩ הוֹצֵ֨אתָ אֶֽת־עַמְּךָ֜ מֵאֶ֤רֶץ מִצְרַ֙יִם֙ בְּיָ֣ד חֲזָקָ֔ה וַתַּֽעַשׂ־לְךָ֥ שֵׁ֖ם כַּיּ֣וֹם הַזֶּ֑ה חָטָ֖אנוּ רָשָֽׁעְנוּ׃ אֲדֹנָ֗י כְּכׇל־צִדְקֹתֶ֙ךָ֙ יָֽשׇׁב־נָ֤א אַפְּךָ֙ וַחֲמָ֣תְךָ֔ מֵעִֽירְךָ֥ יְרוּשָׁלַ֖͏ִם הַר־קׇדְשֶׁ֑ךָ כִּ֤י בַחֲטָאֵ֙ינוּ֙ וּבַעֲוֺנ֣וֹת אֲבֹתֵ֔ינוּ יְרוּשָׁלַ֧͏ִם וְעַמְּךָ֛ לְחֶרְפָּ֖ה לְכׇל־סְבִיבֹתֵֽינוּ׃ וְעַתָּ֣ה ׀ שְׁמַ֣ע אֱלֹהֵ֗ינוּ אֶל־תְּפִלַּ֤ת עַבְדְּךָ֙ וְאֶל־תַּ֣חֲנוּנָ֔יו וְהָאֵ֣ר פָּנֶ֔יךָ עַל־מִקְדָּשְׁךָ֖ הַשָּׁמֵ֑ם לְמַ֖עַן אֲדֹנָֽי׃ הַטֵּ֨ה אֱלֹהַ֥י ׀ אׇזְנְךָ֮ וּֽשְׁמָע֒ \\\\qk{פְּקַ֣ח}{פקחה} עֵינֶ֗יךָ וּרְאֵה֙ שֹֽׁמְמֹתֵ֔ינוּ וְהָעִ֕יר אֲשֶׁר־נִקְרָ֥א שִׁמְךָ֖ עָלֶ֑יהָ כִּ֣י ׀ לֹ֣א עַל־צִדְקֹתֵ֗ינוּ אֲנַ֨חְנוּ מַפִּילִ֤ים תַּחֲנוּנֵ֙ינוּ֙ לְפָנֶ֔יךָ כִּ֖י עַל־רַחֲמֶ֥יךָ הָרַבִּֽים׃ אֲדֹנָ֤י ׀ שְׁמָ֙עָה֙ אֲדֹנָ֣י ׀ סְלָ֔חָה אֲדֹנָ֛י הַֽקְשִׁ֥יבָה וַעֲשֵׂ֖ה אַל־תְּאַחַ֑ר לְמַֽעַנְךָ֣ אֱלֹהַ֔י כִּֽי־שִׁמְךָ֣ נִקְרָ֔א עַל־עִירְךָ֖ וְעַל־עַמֶּֽךָ׃ וְע֨וֹד אֲנִ֤י מְדַבֵּר֙ וּמִתְפַּלֵּ֔ל וּמִתְוַדֶּה֙ חַטָּאתִ֔י וְחַטַּ֖את עַמִּ֣י יִשְׂרָאֵ֑ל וּמַפִּ֣יל תְּחִנָּתִ֗י לִפְנֵי֙ יְיָ֣ אֱלֹהַ֔י עַ֖ל הַר־קֹ֥דֶשׁ אֱלֹהָֽי׃ וְע֛וֹד אֲנִ֥י מְדַבֵּ֖ר בַּתְּפִלָּ֑ה וְהָאִ֣ישׁ גַּבְרִיאֵ֡ל אֲשֶׁר֩ רָאִ֨יתִי בֶחָז֤וֹן בַּתְּחִלָּה֙ מֻעָ֣ף בִּיעָ֔ף נֹגֵ֣עַ אֵלַ֔י כְּעֵ֖ת מִנְחַת־עָֽרֶב׃ וַיָּ֖בֶן וַיְדַבֵּ֣ר עִמִּ֑י וַיֹּאמַ֕ר דָּנִיֵּ֕אל עַתָּ֥ה יָצָ֖אתִי לְהַשְׂכִּילְךָ֥ בִינָֽה׃ בִּתְחִלַּ֨ת תַּחֲנוּנֶ֜יךָ יָצָ֣א דָבָ֗ר וַאֲנִי֙ בָּ֣אתִי לְהַגִּ֔יד כִּ֥י חֲמוּד֖וֹת אָ֑תָּה וּבִין֙ בַּדָּבָ֔ר וְהָבֵ֖ן בַּמַּרְאֶֽה׃ שָׁבֻעִ֨ים שִׁבְעִ֜ים נֶחְתַּ֥ךְ עַֽל־עַמְּךָ֣ ׀ וְעַל־עִ֣יר קׇדְשֶׁ֗ךָ לְכַלֵּ֨א הַפֶּ֜שַׁע \\\\qk{וּלְהָתֵ֤ם}{ולחתם} \\\\qk{חַטָּאת֙}{חטאות} וּלְכַפֵּ֣ר עָוֺ֔ן וּלְהָבִ֖יא צֶ֣דֶק עֹֽלָמִ֑ים וְלַחְתֹּם֙ חָז֣וֹן וְנָבִ֔יא וְלִמְשֹׁ֖חַ קֹ֥דֶשׁ קׇֽדָשִֽׁים׃ וְתֵדַ֨ע וְתַשְׂכֵּ֜ל מִן־מֹצָ֣א דָבָ֗ר לְהָשִׁיב֙ וְלִבְנ֤וֹת יְרֽוּשָׁלַ֙͏ִם֙ עַד־מָשִׁ֣יחַ נָגִ֔יד שָׁבֻעִ֖ים שִׁבְעָ֑ה וְשָׁבֻעִ֞ים שִׁשִּׁ֣ים וּשְׁנַ֗יִם תָּשׁוּב֙ וְנִבְנְתָה֙ רְח֣וֹב וְחָר֔וּץ וּבְצ֖וֹק הָעִתִּֽים׃ וְאַחֲרֵ֤י הַשָּׁבֻעִים֙ שִׁשִּׁ֣ים וּשְׁנַ֔יִם יִכָּרֵ֥ת מָשִׁ֖יחַ וְאֵ֣ין ל֑וֹ וְהָעִ֨יר וְהַקֹּ֜דֶשׁ יַ֠שְׁחִ֠ית עַ֣ם נָגִ֤יד הַבָּא֙ וְקִצּ֣וֹ בַשֶּׁ֔טֶף וְעַד֙ קֵ֣ץ מִלְחָמָ֔ה נֶחֱרֶ֖צֶת שֹׁמֵמֽוֹת׃ וְהִגְבִּ֥יר בְּרִ֛ית לָרַבִּ֖ים שָׁב֣וּעַ אֶחָ֑ד וַחֲצִ֨י הַשָּׁב֜וּעַ יַשְׁבִּ֣ית ׀ זֶ֣בַח וּמִנְחָ֗ה וְעַ֨ל כְּנַ֤ף שִׁקּוּצִים֙ מְשֹׁמֵ֔ם וְעַד־כָּלָה֙ וְנֶ֣חֱרָצָ֔ה תִּתַּ֖ךְ עַל־שֹׁמֵֽם׃ '"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -885,7 +913,7 @@
    "source": [
     "#sample implementations:\n",
     "test = \"%?text=Berakhot.3a&convert=shva\"\n",
-    "test = \"%?text=Genesis.1:1&convert=shemyy&version=MAPM&convert=removeHTML \\n\"\n",
+    "test = \"%?text=Daniel.9&convert=shemyy&convert=qk&version=MAPM&convert=removeHTML \\n\"\n",
     "parserequest(test)\n",
     "#parserequest(test2)"
    ]


### PR DESCRIPTION
versepuller now has the option to convert kri ukhtiv into a LaTeX command, \qk{}{}, where the qere is the first argument and the ketiv is the second.